### PR TITLE
hotfix#1 : sns 로그인 redirecturl(카카오 전송 목적) 강사,회원 통일

### DIFF
--- a/src/components/login/TeacherSocialLogin.jsx
+++ b/src/components/login/TeacherSocialLogin.jsx
@@ -7,14 +7,14 @@ export default function TeacherSocialLogin() {
   const handleKakaoLogin = () => {
     const REST_API_KEY = 'b9759cba8e0cdd5bcdb9d601f5a10ac1';
     const REDIRECT_URI =
-      'http://default-front-07385-26867304-b1e33c76cd35.kr.lb.naverncp.com:30/user/teacherlogin/oauth2/kakao';
+      'http://default-front-07385-26867304-b1e33c76cd35.kr.lb.naverncp.com:30/user/login/oauth2/kakao';
     window.location.href = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&scope=talk_message,profile_nickname,profile_image,account_email`;
   };
 
   const handleNaverLogin = () => {
     const NAVER_REST_API_KEY = 'rIplkSnE1AiVy4P8_7Xh';
     const NAVER_REDIRECT_URI =
-      'http://default-front-07385-26867304-b1e33c76cd35.kr.lb.naverncp.com:30/user/teacherlogin/oauth2/naver';
+      'http://default-front-07385-26867304-b1e33c76cd35.kr.lb.naverncp.com:30/user/login/oauth2/naver';
     window.location.href = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_REST_API_KEY}&state=default1234&redirect_uri=${NAVER_REDIRECT_URI}`;
   };
 


### PR DESCRIPTION
긴급 수정 했습니다. (현재 강사 SNS 로그인 불가)
KAKAO, NAVER 모두 회원, 강사 REDIRECT_URL 통일 했습니다.

이유 : KAKAO,NAVER측에 전달하는 REDIRECT_URL은
SNS 측에 전달해서 이동되는 파라미터이고 이를 통일해보고자 합니다.

하여 해당 부를 통일해도, 백엔드 로직과 관계없이 동작할 것이라고 생각하여 HOTFIX 하였습니다.