### PR TITLE
fix#1 : sns 로그인 시 동일 인 중복 naver or kakao 아이디 회원가입 예외처리

### DIFF
--- a/src/app/user/login/oauth2/kakao/page.jsx
+++ b/src/app/user/login/oauth2/kakao/page.jsx
@@ -16,6 +16,11 @@ export default function KakaoLogin() {
             },
           }
         );
+        if (response.status === 500) {
+          alert('이미 같은 회원 정보로 가입한 SNS 계정이 있습니다.');
+          window.location.href = '/'; 
+          return;
+        }
         if (!response.ok) {
           throw new Error('로그인 실패');
         }

--- a/src/app/user/login/oauth2/naver/page.jsx
+++ b/src/app/user/login/oauth2/naver/page.jsx
@@ -16,6 +16,11 @@ export default function NaverLogin() {
             },
           }
         );
+        if (response.status === 500) {
+          alert('이미 같은 회원 정보로 가입한 SNS 계정이 있습니다.');
+          window.location.href = '/'; 
+          return;
+        }
         if (!response.ok) {
           throw new Error('로그인 실패');
         }

--- a/src/app/user/teacherlogin/oauth2/kakao/page.jsx
+++ b/src/app/user/teacherlogin/oauth2/kakao/page.jsx
@@ -16,6 +16,11 @@ export default function KakaoLogin() {
             },
           }
         );
+        if (response.status === 500) {
+          alert('이미 같은 회원 정보로 가입한 SNS 계정이 있습니다.');
+          window.location.href = '/'; 
+          return;
+        }
         if (!response.ok) {
           throw new Error('로그인 실패');
         }

--- a/src/app/user/teacherlogin/oauth2/naver/page.jsx
+++ b/src/app/user/teacherlogin/oauth2/naver/page.jsx
@@ -16,6 +16,13 @@ export default function NaverLogin() {
             },
           }
         );
+
+        if (response.status === 500) {
+          alert('이미 같은 회원 정보로 가입한 SNS 계정이 있습니다.');
+          window.location.href = '/'; 
+          return;
+        }
+
         if (!response.ok) {
           throw new Error('로그인 실패');
         }


### PR DESCRIPTION
임지혁 -> 으로 네이버 아이디 2개 이상 로그인시, 회원 닉네임이 <네이버 로그인 임지혁>인 계정이 2개 생기고,
db 정확성 문제 해결하기 위해 걸은 UNIQUE 제약에 막혀 500 ERROR RETURN합니다. 
해당 문제 해결했습니다.

예외처리 단순하게 500으로만 진행했고, 그 이유는
1.지금 제가 했던 것 처럼 동일 본명(임지혁)으로 네이버 아이디를 반복으로 만들어서 테스트하는 경우는 굉장히 적을 것 이며,
2. 해당 경우 외의 서버 내 로그인 로직 시 문제 발생은 카카오, 네이버로 인한 것인데 해당 경우는 극소수 일 것이라 판단
3. 이후 예외처리가 추가 된다 하더라도, 그 결과는 결국 메인페이지 redirect일 것이라 판단했습니다. 

해서 500으로만 간단하게 예외 발생 redirect 처리 했습니다.