### PR TITLE
hotfix : search 검색 중 인코딩과정 % 인식 에러 해결

### DIFF
--- a/src/components/items/SearchSection.jsx
+++ b/src/components/items/SearchSection.jsx
@@ -57,6 +57,7 @@ const SearchSection = ({ accessToken }) => {
     event.preventDefault();
     const searchTerm = searchElement.current.value;
     setSearchTerm(searchTerm);
+    const encodedTerm = encodeURIComponent(searchTerm).replace(/%25/g, '%2525');
     if (searchType === 'member') {
       if (!accessToken || accessToken.trim() === '') {
         setShowModal(true);
@@ -64,7 +65,7 @@ const SearchSection = ({ accessToken }) => {
         router.push(`/profile/${searchTerm}`);
       }
     } else if (searchType === 'post') {
-      router.push(`/search/${searchTerm}`);
+      router.push(`/search/${encodedTerm}`);
     }
   };
 
@@ -72,6 +73,7 @@ const SearchSection = ({ accessToken }) => {
     setSearchTerm(item);
     searchElement.current.value = item;
     setAutoCompleteResults([]);
+    const encodedItem = encodeURIComponent(item).replace(/%25/g, '%25');
     if (searchType === 'member') {
       if (!accessToken || accessToken.trim() === '') {
         setShowModal(true);
@@ -79,7 +81,7 @@ const SearchSection = ({ accessToken }) => {
         router.push(`/profile/${item}`);
       }
     } else if (searchType === 'post') {
-      router.push(`/search/${item}`);
+      router.push(`/search/${encodedItem}`);
     }
   };
 

--- a/src/components/items/SearchSection.jsx
+++ b/src/components/items/SearchSection.jsx
@@ -57,7 +57,7 @@ const SearchSection = ({ accessToken }) => {
     event.preventDefault();
     const searchTerm = searchElement.current.value;
     setSearchTerm(searchTerm);
-    const encodedTerm = encodeURIComponent(searchTerm).replace(/%25/g, '%2525');
+    const encodedTerm = encodeURIComponent(searchTerm).replace(/%25/g, '%25');
     if (searchType === 'member') {
       if (!accessToken || accessToken.trim() === '') {
         setShowModal(true);


### PR DESCRIPTION

문제 상황 정리

1. 게시물 검색 중 %가 들어간 검색어를 검색하면

![image](https://github.com/user-attachments/assets/a1fa0a37-7a58-4dd2-850b-c45f85e3a2a5)

2. %20으로 띄어쓰기 인코딩 처리를 하는 것과 겹쳐서 400 bad request 문제 발생

![image](https://github.com/user-attachments/assets/1d584e69-3cf2-46c7-87ec-89ab5f85f4ed)

3. %를 %25로 인코딩하여 처리함 -> 검색 성공
![image](https://github.com/user-attachments/assets/0beac472-ea60-4dfb-84c2-5565dfaca953)

